### PR TITLE
Fix a spelling error in a comment for the Example

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -36,7 +36,7 @@ func Example() {
 	})
 
 	// Next up we instantiate a module which is where we link in all our
-	// imports. We've got one improt so we pass that in here.
+	// imports. We've got one import so we pass that in here.
 	instance, err := NewInstance(module, []*Extern{item.AsExtern()})
 	check(err)
 


### PR DESCRIPTION
Noticed a spelling mistake while reading the first example in the documentation.

Forked, edited, and committed through Github UI. I did not set up a local environment to build and test. I am assuming a change to a comment won't need that level of verification, but if it does, I'd be glad to set up a local environment to run tests.