### PR TITLE
Clarify local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ $ git clone https://github.com/bytecodealliance/wasmtime-go
 
 Next up you'll want to have a [local Wasmtime build
 available](https://bytecodealliance.github.io/wasmtime/contributing-building.html).
+
+You'll need to build at least the `wasmtime-c-api` crate, which, at the time of
+this writing, would be:
+
+```sh
+$ cargo build -p wasmtime-c-api
+```
+
 Once you've got that you can set up the environment of this library with:
 
 ```sh

--- a/ci/local.sh
+++ b/ci/local.sh
@@ -13,6 +13,10 @@ if [ ! -d $build ]; then
   build=$wasmtime/target/debug
 fi
 
+if [ ! -f $build/libwasmtime.a ]; then
+  echo 'Missing libwasmtime.a. Did you `cargo build -p wasmtime-c-api`?'
+fi
+
 mkdir -p build/{include,linux-x86_64,macos-x86_64}
 ln -s $build/libwasmtime.a build/linux-x86_64/libwasmtime.a
 ln -s $build/libwasmtime.a build/macos-x86_64/libwasmtime.a


### PR DESCRIPTION
I stumbled into this when I was attempting to build it locally. The naive approach of just running `cargo build` in `wasmtime` just gives you the CLI, not the c-api.