### PR TITLE
Fix `go get` instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Installation
 
 ```sh
-go get -u github.com/bytecodealliance/wasmtime-go
+go get -u github.com/bytecodealliance/wasmtime-go@v0.16.1
 ```
 
 Be sure to check out the [API documentation][api]!


### PR DESCRIPTION
Since there's no non-v0 tagged releases, go get will download the master branch, which doesn't contain the build files. Once there's a v1, this extra bit can be removed.

Closes #11 