### PR TITLE
Update CI to latest Go 1.13 and 1.14 releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.13.10', '1.14.2']
+        go: ['1.13.12', '1.14.4']
     steps:
     - uses: actions/checkout@v2
 
@@ -49,7 +49,7 @@ jobs:
 
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: '1.14'
     - run: go test -coverprofile cover.out ./...
     - run: go tool cover -html=cover.out -o coverage.html
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
1.14.3 at least had a change to cgo, maybe we'll get lucky.

Not sure what your thoughts are on how many point releases to cover in CI, so I just bumped 1.13 and 1.14 to the latest.