### PR TITLE
Update Go versions verified in CI, clarify 1.14 on macOS warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.13.10', '1.14.2', '1.15.2']
-        exclude:
-        # This is known to segfault (golang/go#39079)
-        - os: macos-latest
-          go: 1.14.2
+        go: ['1.13.15', '1.14.11', '1.15.4']
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ macOS x86\_64 , and Windows x86\_64 currently. Buliding on other platforms will
 need to arrange to build Wasmtime and use `CGO_*` env vars to compile correctly.
 
 This project has been tested with Go 1.13 or later. It is not recommended to
-use Go 1.14 on macOS due to a [bug in the Go runtime][bug].
+use Go 1.14 earlier than Go 1.14.11 on macOS due to a [bug in the Go runtime][bug].
 
 [api]: https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go
 [wasmtime]: https://github.com/bytecodealliance/wasmtime


### PR DESCRIPTION
The fix for golang/go#39079 has been backported to 1.14 as of version 1.14.11
so the macOS warning can be clarified and the build matrix can be updated.