### PR TITLE
Custom types in function return values don't work

### DIFF
--- a/func_test.go
+++ b/func_test.go
@@ -283,6 +283,35 @@ func TestFuncWrapRet2(t *testing.T) {
 	}
 }
 
+type i32alias int32
+
+const (
+	i32_0 i32alias = 0
+	i32_1 i32alias = 1
+	i32_2 i32alias = 2
+)
+
+func TestFuncWrapAliasRet(t *testing.T) {
+	store := NewStore(NewEngine())
+	f := WrapFunc(store, func(which int32) i32alias {
+		if which == 1 {
+			return i32_1
+		} else if which == 2 {
+			return i32_2
+		}
+
+		return i32_0
+	})
+	result, trap := f.Call(1)
+	if trap != nil {
+		panic(trap)
+	}
+
+	if result != i32_1 {
+		panic(fmt.Sprintf("wrong result, expected %q, got %q", i32_1, result))
+	}
+}
+
 func TestFuncWrapRetError(t *testing.T) {
 	store := NewStore(NewEngine())
 	f := WrapFunc(store, func(c *Caller) *Trap {


### PR DESCRIPTION
This is not *really* a pull request. I only created it as one to show an illustrative example of the problem.

So, @jedisct1 found out in https://github.com/avidal/fastlike/pull/11 that using a custom return type (that aliases `int32`) results in the wasm guest always receiving a 0.

I added a test here that shows the same behavior. It seems that when the function is wrapped (via `WrapFunc`), the custom type is added to the wasmtime func signature as an `int32` via `typeToValType`. But on the way out, via the trampoline, the return value hits the default branch since the type switch is (in this case), `wasmtime.i32alias` and not `int32`, which results in it being an `ExternRef` and then triggering the trap in wasmtime: `panic: function attempted to return an incompatible value`

I'm not sure what the proper behavior here is, but it seems like the type should be consistent when wrapping vs calling. Either that means updating the trampoline code to use similar semantics as wrapping or treating this type alias as an extern at wrapping time.