### PR TITLE
Test specifically for int32/etc types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         bazelisk test :go_default_test
       if: matrix.os != 'windows-latest'
     - name: Ready msys2
-      uses: msys2/setup-msys2@v1
+      uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
         update: true

--- a/func.go
+++ b/func.go
@@ -243,14 +243,20 @@ func WrapFunc(
 }
 
 func typeToValType(ty reflect.Type) *ValType {
-	switch ty.Kind() {
-	case reflect.Int32:
+	var a int32
+	if ty == reflect.TypeOf(a) {
 		return NewValType(KindI32)
-	case reflect.Int64:
+	}
+	var b int64
+	if ty == reflect.TypeOf(b) {
 		return NewValType(KindI64)
-	case reflect.Float32:
+	}
+	var c float32
+	if ty == reflect.TypeOf(c) {
 		return NewValType(KindF32)
-	case reflect.Float64:
+	}
+	var d float64
+	if ty == reflect.TypeOf(d) {
 		return NewValType(KindF64)
 	}
 	var f *Func

--- a/func_test.go
+++ b/func_test.go
@@ -468,3 +468,26 @@ func TestInterestingTypes(t *testing.T) {
 	WrapFunc(store, func(*Store) {})
 	WrapFunc(store, func() *Store { return nil })
 }
+
+type i32alias int32
+
+const (
+	i32_0 i32alias = 0
+	i32_1 i32alias = 1
+	i32_2 i32alias = 2
+)
+
+func TestFuncWrapAliasRet(t *testing.T) {
+	store := NewStore(NewEngine())
+	f := WrapFunc(store, func(which i32alias) i32alias {
+		return which
+	})
+	result, trap := f.Call(i32_1)
+	if trap != nil {
+		panic(trap)
+	}
+
+	if result != i32_1 {
+		panic(fmt.Sprintf("wrong result, expected %q, got %q", i32_1, result))
+	}
+}


### PR DESCRIPTION
Current usage of `Kind()` for type test ends up matching alias types by
accident, but it's easier if those go into the externref bucket.

Closes #41