### PR TITLE
Make build directories as valid (empty) go packages.

### DIFF
--- a/build/include/empty.go
+++ b/build/include/empty.go
@@ -1,0 +1,1 @@
+package include

--- a/build/linux-x86_64/empty.go
+++ b/build/linux-x86_64/empty.go
@@ -1,0 +1,1 @@
+package linux_x86_64

--- a/build/macos-x86_64/empty.go
+++ b/build/macos-x86_64/empty.go
@@ -1,0 +1,1 @@
+package macos_x86_64

--- a/build/windows-x86_64/empty.go
+++ b/build/windows-x86_64/empty.go
@@ -1,0 +1,1 @@
+package windows_x86_64


### PR DESCRIPTION
go mod vendor will not copy the header and library directory contents
not referred in any go source code. A common workaround is to add "_"
imports to such directories with necessary cgo files, but doing so
requires rendering such directories as valid go packages. This patch
does exactly that.

With this patch, one can vendor the C headers and libraries by
introducing the following imports in the code using the wasmtime-go
bindings.

import (
	_ "github.com/bytecodealliance/wasmtime-go/build/include"
        _ "github.com/bytecodealliance/wasmtime-go/build/linux-x86_64"
        _ "github.com/bytecodealliance/wasmtime-go/build/macos-x86_64"
)

Optionally, one could consider introducing these imports to the
"github.com/bytecodealliance/wasmtime-go" package itself.

For more information about the underlying limitation of vendoring, see
for example: https://github.com/golang/go/issues/26366