### PR TITLE
Fix management of global `freelist` entries

### DIFF
--- a/ffi.go
+++ b/ffi.go
@@ -3,7 +3,7 @@ package wasmtime
 // #cgo CFLAGS:-I${SRCDIR}/build/include
 // #cgo !windows LDFLAGS:-lwasmtime -lm -ldl
 // #cgo windows CFLAGS:-DWASM_API_EXTERN= -DWASI_API_EXTERN=
-// #cgo windows LDFLAGS:-lwasmtime -luserenv -lole32 -lntdll -lws2_32 -lkernel32
+// #cgo windows LDFLAGS:-lwasmtime -luserenv -lole32 -lntdll -lws2_32 -lkernel32 -lbcrypt
 // #cgo linux,amd64 LDFLAGS:-L${SRCDIR}/build/linux-x86_64
 // #cgo darwin,amd64 LDFLAGS:-L${SRCDIR}/build/macos-x86_64
 // #cgo windows,amd64 LDFLAGS:-L${SRCDIR}/build/windows-x86_64

--- a/shims.c
+++ b/shims.c
@@ -1,15 +1,13 @@
 #include "_cgo_export.h"
 #include "shims.h"
 
-__thread size_t caller_id;
-
 static wasm_trap_t* trampoline(
    const wasmtime_caller_t *caller,
    void *env,
    const wasm_val_vec_t *args,
    wasm_val_vec_t *results
 ) {
-    return goTrampolineNew(caller_id, (wasmtime_caller_t*) caller, (size_t) env, (wasm_val_vec_t*) args, results);
+    return goTrampolineNew((wasmtime_caller_t*) caller, (size_t) env, (wasm_val_vec_t*) args, results);
 }
 
 static wasm_trap_t* wrap_trampoline(
@@ -18,7 +16,7 @@ static wasm_trap_t* wrap_trampoline(
    const wasm_val_vec_t *args,
    wasm_val_vec_t *results
 ) {
-    return goTrampolineWrap(caller_id, (wasmtime_caller_t*) caller, (size_t) env, (wasm_val_vec_t*) args, results);
+    return goTrampolineWrap((wasmtime_caller_t*) caller, (size_t) env, (wasm_val_vec_t*) args, results);
 }
 
 wasm_func_t *c_func_new_with_env(wasm_store_t *store, wasm_functype_t *ty, size_t env, int wrap) {
@@ -31,13 +29,9 @@ wasmtime_error_t *go_wasmtime_func_call(
     wasm_func_t *func,
     const wasm_val_vec_t *args,
     wasm_val_vec_t *results,
-    wasm_trap_t **trap,
-    size_t go_id
+    wasm_trap_t **trap
 ) {
-  size_t prev_caller_id = caller_id;
-  caller_id = go_id;
   wasmtime_error_t *ret = wasmtime_func_call(func, args, results, trap);
-  caller_id = prev_caller_id;
   return ret;
 }
 

--- a/shims.h
+++ b/shims.h
@@ -25,8 +25,7 @@ wasmtime_error_t *go_wasmtime_func_call(
     wasm_func_t *func,
     const wasm_val_vec_t *args,
     wasm_val_vec_t *results,
-    wasm_trap_t **trap,
-    size_t go_id
+    wasm_trap_t **trap
 );
 void go_init_i32(wasm_val_t *val, int32_t i);
 void go_init_i64(wasm_val_t *val, int64_t i);


### PR DESCRIPTION
This commit fixes a few issues with management of global `freelist`
entries indicating how to acquire the `*freeList` when a function is
called:

* Recursive calls into WebAssembly wouldn't work correctly and would too
  eagerly remove `*freeList` entries.
* Calls to functions through instantiation were not handled properly
  with global `*freeList` entries set.

This commit fixes these issues by encapsulating global freelist
management in an `enterWasm` function which is now called from
instantiation as well and handles all of these pieces accordingly.

Closes #58