### PR TITLE
Add directory build/include/wasmtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,10 @@ jobs:
         bazelisk build --subcommands=pretty_print --verbose_failures --compiler=mingw-gcc :go_default_library
         bazelisk test --subcommands=pretty_print --verbose_failures --compiler=mingw-gcc :go_default_test
       if: matrix.os == 'windows-latest'
+    - name: Test vendoring on *nix
+      shell: bash
+      run: ./ci/test-vendoring.sh
+      if: matrix.os != 'windows-latest'
 
   coverage:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 /bazel-*
+test-vendoring-project

--- a/build/include/wasmtime/empty.go
+++ b/build/include/wasmtime/empty.go
@@ -1,0 +1,1 @@
+package wasmtime

--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -5,7 +5,6 @@ import urllib.request
 import zipfile
 import tarfile
 import io
-import sys
 import os
 import shutil
 import glob
@@ -52,3 +51,9 @@ for dylib in glob.glob("build/**/*.dylib"):
     os.remove(dylib)
 for dylib in glob.glob("build/**/*.so"):
     os.remove(dylib)
+
+for subdir, dirs, files in os.walk("build"):
+    dir_name = os.path.basename(os.path.normpath(subdir))
+    file_path = os.path.join(subdir, "empty.go")
+    with open(file_path, "w") as empty_file:
+        empty_file.write("package %s\n" % dir_name.replace("-", "_"))

--- a/ci/local.sh
+++ b/ci/local.sh
@@ -9,9 +9,10 @@ fi
 # Clean and re-create "build" directory hierarchy
 rm -rf build
 for d in "include" "include/wasmtime" "linux-x86_64" "macos-x86_64" "windows-x86_64"; do
-  mkdir -p "build/$d"
+  path="build/$d"
+  mkdir -p "$path"
   name=$(basename $d)
-  echo "package ${name/-/_}" > "build/$d/empty.go"
+  echo "package ${name/-/_}" > "$path/empty.go"
 done
 
 build="$wasmtime/target/release"

--- a/ci/local.sh
+++ b/ci/local.sh
@@ -6,19 +6,27 @@ if [ "$wasmtime" = "" ]; then
   exit 1
 fi
 
+# Clean and re-create "build" directory hierarchy
 rm -rf build
+for d in "include" "include/wasmtime" "linux-x86_64" "macos-x86_64" "windows-x86_64"; do
+  mkdir -p "build/$d"
+  name=$(basename $d)
+  echo "package ${name/-/_}" > "build/$d/empty.go"
+done
 
-build=$wasmtime/target/release
-if [ ! -d $build ]; then
-  build=$wasmtime/target/debug
+build="$wasmtime/target/release"
+if [ ! -d "$build" ]; then
+  build="$wasmtime/target/debug"
 fi
+# Use absolute path for symbolic links
+build=$(readlink -f "$build")
 
-if [ ! -f $build/libwasmtime.a ]; then
+if [ ! -f "$build/libwasmtime.a" ]; then
   echo 'Missing libwasmtime.a. Did you `cargo build -p wasmtime-c-api`?'
 fi
 
-mkdir -p build/{include,linux-x86_64,macos-x86_64}
-ln -s $build/libwasmtime.a build/linux-x86_64/libwasmtime.a
-ln -s $build/libwasmtime.a build/macos-x86_64/libwasmtime.a
-cp $wasmtime/crates/c-api/include/*.h build/include
-cp $wasmtime/crates/c-api/wasm-c-api/include/*.h build/include
+ln -s "$build/libwasmtime.a" build/linux-x86_64/libwasmtime.a
+ln -s "$build/libwasmtime.a" build/macos-x86_64/libwasmtime.a
+cp "$wasmtime"/crates/c-api/include/*.h build/include
+cp -r "$wasmtime"/crates/c-api/include/wasmtime build/include
+cp "$wasmtime"/crates/c-api/wasm-c-api/include/*.h build/include

--- a/ci/test-vendoring.sh
+++ b/ci/test-vendoring.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This script tests the usage of wasmtime-go in a Go project
+# that vendors its dependencies. This is used to check if
+# all the header files and binaries are well copied in the
+# vendor directory.
+
+# Create a test directory
+rm -rf test-vendoring-project
+mkdir test-vendoring-project && cd test-vendoring-project || return 1
+
+# Initialize a Go project
+go mod init "test-vendoring-project"
+
+# Add dependency to wasmtime-go
+cat << E0F >> go.mod
+require "github.com/bytecodealliance/wasmtime-go" v0.0.0
+replace "github.com/bytecodealliance/wasmtime-go" v0.0.0 => "../"
+E0F
+
+# Add a basic test which uses wasmtime-go
+cat << "E0F" >> main_test.go
+package main
+
+import (
+	"testing"
+
+	"github.com/bytecodealliance/wasmtime-go"
+)
+
+func TestMain(t *testing.T) {
+	wasmtime.NewStore(wasmtime.NewEngine())
+}
+E0F
+
+# Vendor dependency
+go mod vendor
+
+# Then execute the test
+go test .
+
+echo "Success"

--- a/ffi.go
+++ b/ffi.go
@@ -9,8 +9,19 @@ package wasmtime
 // #cgo windows,amd64 LDFLAGS:-L${SRCDIR}/build/windows-x86_64
 // #include <wasm.h>
 import "C"
-import "runtime"
-import "unsafe"
+import (
+	"runtime"
+	"unsafe"
+
+	// Import these build directories in order to have them
+	// included in vendored dependencies.
+	// Cf. https://github.com/golang/go/issues/26366
+	_ "github.com/bytecodealliance/wasmtime-go/build/include"
+	_ "github.com/bytecodealliance/wasmtime-go/build/include/wasmtime"
+	_ "github.com/bytecodealliance/wasmtime-go/build/linux-x86_64"
+	_ "github.com/bytecodealliance/wasmtime-go/build/macos-x86_64"
+	_ "github.com/bytecodealliance/wasmtime-go/build/windows-x86_64"
+)
 
 // # What's up with `ptr()` methods?
 //

--- a/ffi.go
+++ b/ffi.go
@@ -9,19 +9,8 @@ package wasmtime
 // #cgo windows,amd64 LDFLAGS:-L${SRCDIR}/build/windows-x86_64
 // #include <wasm.h>
 import "C"
-import (
-	"runtime"
-	"unsafe"
-
-	// Import these build directories in order to have them
-	// included in vendored dependencies.
-	// Cf. https://github.com/golang/go/issues/26366
-	_ "github.com/bytecodealliance/wasmtime-go/build/include"
-	_ "github.com/bytecodealliance/wasmtime-go/build/include/wasmtime"
-	_ "github.com/bytecodealliance/wasmtime-go/build/linux-x86_64"
-	_ "github.com/bytecodealliance/wasmtime-go/build/macos-x86_64"
-	_ "github.com/bytecodealliance/wasmtime-go/build/windows-x86_64"
-)
+import "runtime"
+import "unsafe"
 
 // # What's up with `ptr()` methods?
 //

--- a/includebuild.go
+++ b/includebuild.go
@@ -1,0 +1,18 @@
+// +build includebuild
+
+package wasmtime
+
+// This file is not built and not included in BUILD.bazel;
+// it is only used to prevent "go mod vendor" to prune the
+// build directory.
+
+import (
+	// Import these build directories in order to have them
+	// included in vendored dependencies.
+	// Cf. https://github.com/golang/go/issues/26366
+	_ "github.com/bytecodealliance/wasmtime-go/build/include"
+	_ "github.com/bytecodealliance/wasmtime-go/build/include/wasmtime"
+	_ "github.com/bytecodealliance/wasmtime-go/build/linux-x86_64"
+	_ "github.com/bytecodealliance/wasmtime-go/build/macos-x86_64"
+	_ "github.com/bytecodealliance/wasmtime-go/build/windows-x86_64"
+)


### PR DESCRIPTION
Following the update to Wasmtime's new C API in #81, the header files are now not only in build/local, but also in build/local/wasmtime.

This commit adds the directory "build/include/wasmtime" as a valid empty go package, like it was done in #45 for the other build directories.

It also addapts `ci/local.sh` to:
- copy the additional header files in build/include/wasmtime
- stop this script from removing the "empty.go" files.
