### PR TITLE
Fix bash script on macOS

### DIFF
--- a/ci/local.sh
+++ b/ci/local.sh
@@ -20,7 +20,7 @@ if [ ! -d "$build" ]; then
   build="$wasmtime/target/debug"
 fi
 # Use absolute path for symbolic links
-build=$(readlink -f "$build")
+build=$(cd "$build" && pwd)
 
 if [ ! -f "$build/libwasmtime.a" ]; then
   echo 'Missing libwasmtime.a. Did you `cargo build -p wasmtime-c-api`?'


### PR DESCRIPTION
`readlink -f` is not existing in macOS, so this commit uses another way to get an absolute path for wasmtime build directory.

Fixes #87
