### PR TITLE
Bind `wasmtime_linker_define_func`

### DIFF
--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -13,6 +13,7 @@ urls = [
     ['wasmtime-dev-x86_64-mingw-c-api.zip', 'windows-x86_64'],
     ['wasmtime-dev-x86_64-linux-c-api.tar.xz', 'linux-x86_64'],
     ['wasmtime-dev-x86_64-macos-c-api.tar.xz', 'macos-x86_64'],
+    ['wasmtime-dev-aarch64-linux-c-api.tar.xz', 'linux-aarch64'],
 ]
 
 try:

--- a/engine.go
+++ b/engine.go
@@ -2,7 +2,9 @@ package wasmtime
 
 // #include <wasm.h>
 import "C"
-import "runtime"
+import (
+	"runtime"
+)
 
 // Engine is an instance of a wasmtime engine which is used to create a `Store`.
 //

--- a/ffi.go
+++ b/ffi.go
@@ -5,12 +5,15 @@ package wasmtime
 // #cgo windows CFLAGS:-DWASM_API_EXTERN= -DWASI_API_EXTERN=
 // #cgo windows LDFLAGS:-lwasmtime -luserenv -lole32 -lntdll -lws2_32 -lkernel32 -lbcrypt
 // #cgo linux,amd64 LDFLAGS:-L${SRCDIR}/build/linux-x86_64
+// #cgo linux,arm64 LDFLAGS:-L${SRCDIR}/build/linux-aarch64
 // #cgo darwin,amd64 LDFLAGS:-L${SRCDIR}/build/macos-x86_64
 // #cgo windows,amd64 LDFLAGS:-L${SRCDIR}/build/windows-x86_64
 // #include <wasm.h>
 import "C"
-import "runtime"
-import "unsafe"
+import (
+	"runtime"
+	"unsafe"
+)
 
 // # What's up with `ptr()` methods?
 //

--- a/shims.c
+++ b/shims.c
@@ -31,11 +31,36 @@ static wasm_trap_t* wrap_trampoline(
         results, nresults);
 }
 
-void go_func_new(wasmtime_context_t *store, wasm_functype_t *ty, size_t env, int wrap, wasmtime_func_t *ret) {
+void go_func_new(
+    wasmtime_context_t *store,
+    wasm_functype_t *ty,
+    size_t env,
+    int wrap,
+    wasmtime_func_t *ret
+) {
   wasmtime_func_callback_t callback = trampoline;
   if (wrap)
     callback = wrap_trampoline;
   return wasmtime_func_new(store, ty, callback, (void*) env, NULL, ret);
+}
+
+wasmtime_error_t *go_linker_define_func(
+    wasmtime_linker_t *linker,
+    const char *module,
+    size_t module_len,
+    const char *name,
+    size_t name_len,
+    const wasm_functype_t *ty,
+    int wrap,
+    size_t env
+) {
+  wasmtime_func_callback_t cb = trampoline;
+  void(*finalizer)(void*) = goFinalizeFuncNew;
+  if (wrap) {
+    cb = wrap_trampoline;
+    finalizer = goFinalizeFuncWrap;
+  }
+  return wasmtime_linker_define_func(linker, module, module_len, name, name_len, ty, cb, (void*) env, finalizer);
 }
 
 wasmtime_externref_t *go_externref_new(size_t env) {

--- a/shims.h
+++ b/shims.h
@@ -2,7 +2,17 @@
 #include <wasmtime.h>
 
 wasmtime_store_t *go_store_new(wasm_engine_t *engine, size_t env);
-void go_func_new(wasmtime_context_t *context, wasm_functype_t *ty, size_t env, int wrap, wasmtime_func_t *ret);
+void go_func_new(wasmtime_context_t *context, wasm_functype_t *ty, size_t env, int wrap,  wasmtime_func_t *ret);
+wasmtime_error_t *go_linker_define_func(
+    wasmtime_linker_t *linker,
+    const char *module,
+    size_t module_len,
+    const char *name,
+    size_t name_len,
+    const wasm_functype_t *ty,
+    int wrap,
+    size_t env
+);
 wasmtime_externref_t *go_externref_new(size_t env);
 
 #define EACH_UNION_ACCESSOR(name) \


### PR DESCRIPTION
This adds corresponding methods to the `Linker` type to define
Go-defined host functions into the linker in a store-independent
fashion.