### PR TITLE
Link with `-pthread` on Unix

### DIFF
--- a/ffi.go
+++ b/ffi.go
@@ -1,7 +1,7 @@
 package wasmtime
 
 // #cgo CFLAGS:-I${SRCDIR}/build/include
-// #cgo !windows LDFLAGS:-lwasmtime -lm -ldl
+// #cgo !windows LDFLAGS:-lwasmtime -lm -ldl -pthread
 // #cgo windows CFLAGS:-DWASM_API_EXTERN= -DWASI_API_EXTERN=
 // #cgo windows LDFLAGS:-lwasmtime -luserenv -lole32 -lntdll -lws2_32 -lkernel32 -lbcrypt
 // #cgo linux,amd64 LDFLAGS:-L${SRCDIR}/build/linux-x86_64


### PR DESCRIPTION
Try to fix some unresolved symbols in the `rand` crate on some Unix
platforms.

Closes #94