### PR TITLE
Add basic macOS arm64 support

### DIFF
--- a/build/macos-aarch64/empty.go
+++ b/build/macos-aarch64/empty.go
@@ -1,0 +1,1 @@
+package macos_aarch64

--- a/ci/local.sh
+++ b/ci/local.sh
@@ -8,7 +8,7 @@ fi
 
 # Clean and re-create "build" directory hierarchy
 rm -rf build
-for d in "include" "include/wasmtime" "linux-x86_64" "macos-x86_64" "windows-x86_64"; do
+for d in "include" "include/wasmtime" "linux-x86_64" "macos-x86_64" "windows-x86_64" "macos-aarch64"; do
   path="build/$d"
   mkdir -p "$path"
   name=$(basename $d)
@@ -26,8 +26,10 @@ if [ ! -f "$build/libwasmtime.a" ]; then
   echo 'Missing libwasmtime.a. Did you `cargo build -p wasmtime-c-api`?'
 fi
 
-ln -s "$build/libwasmtime.a" build/linux-x86_64/libwasmtime.a
-ln -s "$build/libwasmtime.a" build/macos-x86_64/libwasmtime.a
+for d in "linux-x86_64" "macos-x86_64" "macos-aarch64"; do
+  ln -s "$build/libwasmtime.a" "build/$d/libwasmtime.a"
+done
+
 cp "$wasmtime"/crates/c-api/include/*.h build/include
 cp -r "$wasmtime"/crates/c-api/include/wasmtime build/include
 cp "$wasmtime"/crates/c-api/wasm-c-api/include/*.h build/include

--- a/ffi.go
+++ b/ffi.go
@@ -7,6 +7,7 @@ package wasmtime
 // #cgo linux,amd64 LDFLAGS:-L${SRCDIR}/build/linux-x86_64
 // #cgo linux,arm64 LDFLAGS:-L${SRCDIR}/build/linux-aarch64
 // #cgo darwin,amd64 LDFLAGS:-L${SRCDIR}/build/macos-x86_64
+// #cgo darwin,arm64 LDFLAGS:-L${SRCDIR}/build/macos-aarch64
 // #cgo windows,amd64 LDFLAGS:-L${SRCDIR}/build/windows-x86_64
 // #include <wasm.h>
 import "C"

--- a/includebuild.go
+++ b/includebuild.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/bytecodealliance/wasmtime-go/build/include"
 	_ "github.com/bytecodealliance/wasmtime-go/build/include/wasmtime"
 	_ "github.com/bytecodealliance/wasmtime-go/build/linux-x86_64"
+	_ "github.com/bytecodealliance/wasmtime-go/build/macos-aarch64"
 	_ "github.com/bytecodealliance/wasmtime-go/build/macos-x86_64"
 	_ "github.com/bytecodealliance/wasmtime-go/build/windows-x86_64"
 )


### PR DESCRIPTION
This commit adds basic support for building on M1 Macs. For now, `libwasmtime.a` for macos_aarch64 must be built manually, but that part seems to be working fine.

This workflow works on my M1 MacBook running Monterey:

```
cd wasmtime
cargo build -p wasmtime-c-api --release

cd ../wasmtime-go
./ci/local.sh ../wasmtime
```

All the tests pass except for `TestTrapFrames` and `TestTrapModuleName`:

```
=== RUN   TestTrapFrames
    trap_test.go:34: expected 3 frames, got 1
--- FAIL: TestTrapFrames (0.00s)
=== RUN   TestTrapModuleName
    trap_test.go:90: expected 1 frame, got 0
--- FAIL: TestTrapModuleName (0.00s)
```