### PR TITLE
ci/download-wasmtime.py: keep empty.go files

### DIFF
--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -17,11 +17,13 @@ urls = [
 ]
 
 try:
-    shutil.rmtree('build')
+    # keep directory structure, only iremove files
+    for subdir, dirs, files in os.walk("build"):
+        dir_name = os.path.basename(os.path.normpath(subdir))
+        for file in files:
+            os.unlink(os.path.join(subdir, file))
 except FileNotFoundError:
-    pass
-
-os.makedirs('build')
+    os.makedirs('build')
 
 for i, arr in enumerate(urls):
     filename, dirname = arr
@@ -41,9 +43,9 @@ for i, arr in enumerate(urls):
 
     src = filename.replace('.zip', '').replace('.tar.xz', '')
     if i == 0:
-        os.rename(src + '/include', 'build/include')
+        shutil.copytree(src + '/include', 'build/include', dirs_exist_ok=True)
 
-    os.rename(src + '/lib', 'build/' + dirname)
+    shutil.copytree(src + '/lib', 'build/' + dirname, dirs_exist_ok=True)
     shutil.rmtree(src)
 
 for dylib in glob.glob("build/**/*.dll"):


### PR DESCRIPTION
Before, the download-wasmtime.py script would remove build/, and
add empty.go files for every architecture it has unpacked library
artifacts for. Since includebuild.go mentions more than that,
notably macos-aarch64 (which there are no unpacked library
files), we ended up in a state where the go module couldn't be
built.

Now, the script will remove all regular files in build/, and re-
populate the directory from the downloaded tarballs. In its final
step, it drops empty.go files in all directories, even those it
that did not get recreated.

Fixes #112.

This is `find build` after running the script locally:

    $ find build
    build
    build/macos-aarch64
    build/macos-aarch64/empty.go
    build/linux-x86_64
    build/linux-x86_64/empty.go
    build/linux-x86_64/libwasmtime.a
    build/linux-aarch64
    build/linux-aarch64/empty.go
    build/linux-aarch64/libwasmtime.a
    build/include
    build/include/wasmtime
    build/include/wasmtime/error.h
    build/include/wasmtime/trap.h
    build/include/wasmtime/config.h
    build/include/wasmtime/global.h
    build/include/wasmtime/empty.go
    build/include/wasmtime/memory.h
    build/include/wasmtime/linker.h
    build/include/wasmtime/table.h
    build/include/wasmtime/instance.h
    build/include/wasmtime/extern.h
    build/include/wasmtime/func.h
    build/include/wasmtime/module.h
    build/include/wasmtime/store.h
    build/include/wasmtime/val.h
    build/include/wasmtime.h
    build/include/wasi.h
    build/include/empty.go
    build/include/wasm.h
    build/include/doc-wasm.h
    build/empty.go
    build/macos-x86_64
    build/macos-x86_64/empty.go
    build/macos-x86_64/libwasmtime.a
    build/windows-x86_64
    build/windows-x86_64/empty.go
    build/windows-x86_64/libwasmtime.a

Signed-off-by: Stephan Renatus <stephan.renatus@gmail.com>