### PR TITLE
using dynamic lib default in linux-x86_64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,27 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - run: go vet
+    - run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:build/linux-x86_64/
+        go test
+      name: Run go test
+      if: matrix.os == 'ubuntu-latest'
+    - run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:build/linux-x86_64/
+        go test -tags debug
+      name: Run go test -tags debug
+      if: matrix.os == 'ubuntu-latest'
+    - run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:build/linux-x86_64/
+        go test -tags debug
+      name: Run go test -tags debug
+      if: matrix.os == 'ubuntu-latest'
     - run: go test
+      if: matrix.os != 'ubuntu-latest'
     - run: go test -tags debug
+      if: matrix.os != 'ubuntu-latest'
     - run: go test -tags debug
+      if: matrix.os != 'ubuntu-latest'
       env:
         GODEBUG: cgocheck=2
         GOGC: 1
@@ -81,7 +99,9 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.18'
-    - run: go test -coverprofile cover.out ./...
+    - run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:build/linux-x86_64/
+        go test -coverprofile cover.out ./...
     - run: go tool cover -html=cover.out -o coverage.html
     - uses: actions/upload-artifact@v1
       with:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,7 @@ cc_library(
     name = "wasmtime",
     srcs = select({
         "@io_bazel_rules_go//go/platform:darwin_amd64": ["build/macos-x86_64/libwasmtime.a"],
-        "@io_bazel_rules_go//go/platform:linux_amd64": ["build/linux-x86_64/libwasmtime.a"],
+        "@io_bazel_rules_go//go/platform:linux_amd64": ["build/linux-x86_64/libwasmtime.so"],
         "@io_bazel_rules_go//go/platform:windows_amd64": ["build/windows-x86_64/libwasmtime.a"],
     }),
     hdrs = glob(["build/include/**/*.h"]),

--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -59,8 +59,6 @@ for dylib in glob.glob("build/**/*.dll.a"):
     os.remove(dylib)
 for dylib in glob.glob("build/**/*.dylib"):
     os.remove(dylib)
-for dylib in glob.glob("build/**/*.so"):
-    os.remove(dylib)
 
 for subdir, dirs, files in os.walk("build"):
     dir_name = os.path.basename(os.path.normpath(subdir))


### PR DESCRIPTION
Like wasmer, use dynamic library by default in linux-x86_64 to prevent duplicate symbol. (#150)  