### PR TITLE
enh: Add support for apple silicon in bazel.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,7 @@ cc_library(
         "@io_bazel_rules_go//go/platform:darwin_amd64": ["build/macos-x86_64/libwasmtime.a"],
         "@io_bazel_rules_go//go/platform:linux_amd64": ["build/linux-x86_64/libwasmtime.a"],
         "@io_bazel_rules_go//go/platform:windows_amd64": ["build/windows-x86_64/libwasmtime.a"],
+        "@io_bazel_rules_go//go/platform:darwin_arm64": ["build/macos-aarch64/libwasmtime.a"],
     }),
     hdrs = glob(["build/include/**/*.h"]),
     includes = ["build/include"],


### PR DESCRIPTION
## Summary
Adds support for apple silicon using bazel.

## Testing
Tested locally on an M2 Pro chip.

Closes #176 