### PR TITLE
Expose max stack size setting in Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,6 +62,15 @@ func (cfg *Config) SetDebugInfo(enabled bool) {
 	runtime.KeepAlive(cfg)
 }
 
+// SetMaxWasmStack configures the maximum stack size, in bytes, that JIT code can use.
+// The amount of stack space that wasm takes is always relative to the first invocation of wasm on the stack.
+// Recursive calls with host frames in the middle will all need to fit within this setting.
+// Note that this setting is not interpreted with 100% precision.
+func (cfg *Config) SetMaxWasmStack(size int) {
+	C.wasmtime_config_max_wasm_stack_set(cfg.ptr(), C.size_t(size))
+	runtime.KeepAlive(cfg)
+}
+
 // SetWasmThreads configures whether the wasm threads proposal is enabled
 func (cfg *Config) SetWasmThreads(enabled bool) {
 	C.wasmtime_config_wasm_threads_set(cfg.ptr(), C.bool(enabled))

--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestConfig(t *testing.T) {
 	NewConfig().SetDebugInfo(true)
+	NewConfig().SetMaxWasmStack(8388608)
 	NewConfig().SetWasmThreads(true)
 	NewConfig().SetWasmReferenceTypes(true)
 	NewConfig().SetWasmSIMD(true)


### PR DESCRIPTION
Hello, thanks for wastime-go. I appreciate everyone's hard work and I'm enjoying building things with it.

This PR adds support for configuring the max wasm stack size. For the godoc comment, I borrowed the language from `wasmtime/config.h`, which I found to be very helpful in clarifying the behavior of recursive calls. I made the size parameter an `int` to match with the `len(x)` builtin. I figure that's the closest thing Go has to `size_t`.

Please feel free to suggest any changes!