### PR TITLE
Add SetMaxWasmStack test

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -27,3 +27,10 @@ func TestEngineInvalidatesConfig(t *testing.T) {
 		require.Nil(t, engine)
 	}
 }
+
+func TestEngineMaxStackSize(t *testing.T) {
+	config := NewConfig()
+	config.SetMaxWasmStack(8388608) // 8MiB
+	engine := NewEngineWithConfig(config)
+	require.NotNil(t, engine)
+}


### PR DESCRIPTION
Adds a simple test for Config.SetMaxWasmStack.

As mentioned in https://github.com/bytecodealliance/wasmtime-go/issues/182#issuecomment-1648595522, if my theory is correct this should fail against the current release.