### PR TITLE
Add trap code OutOfFuel

### DIFF
--- a/trap.go
+++ b/trap.go
@@ -50,6 +50,8 @@ const (
 	UnreachableCodeReached
 	// Interrupt: execution has been interrupted.
 	Interrupt
+	// OutOfFuel: Execution has run out of the configured fuel amount.
+	OutOfFuel
 )
 
 // NewTrap creates a new `Trap` with the `name` and the type provided.


### PR DESCRIPTION
Add Go equivalent of [`WASMTIME_TRAP_CODE_OUT_OF_FUEL`](https://docs.wasmtime.dev/c-api/trap_8h.html#aaf65157179087a40bcf0e7713faa42dfaa27c0db4b041af888a7c0fea7acf8802)