### PR TITLE
Use unsafe.Slice in Memory.UnsafeData

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
+    sha256 = "91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
     ],
 )
 
@@ -63,6 +63,6 @@ go_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.16")
+go_register_toolchains(version = "1.21.1")
 
 gazelle_dependencies()

--- a/memory.go
+++ b/memory.go
@@ -56,13 +56,8 @@ func (mem *Memory) Data(store Storelike) unsafe.Pointer {
 // `m` alive for long enough while you're using the `[]byte` slice. If the
 // `[]byte` slice is used after `m` is GC'd then that is undefined behavior.
 func (mem *Memory) UnsafeData(store Storelike) []byte {
-	// see https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
-	const MaxLen = 1 << 32
 	length := mem.DataSize(store)
-	if length >= MaxLen {
-		panic("memory is too big")
-	}
-	return (*[MaxLen]byte)(mem.Data(store))[:length:length]
+	return unsafe.Slice((*byte)(mem.Data(store)), length)
 }
 
 // DataSize returns the size, in bytes, that `Data()` is valid for


### PR DESCRIPTION
Go 1.17 added [unsafe.Slice](https://pkg.go.dev/unsafe#Slice), which avoids the 32-bit overflow issue mentioned in #199. I believe this also lets us use memories larger than 4GB (for future wasm64 stuff).