### PR TITLE
Add explicit `Close` methods to most types

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestEngine(t *testing.T) {
-	NewEngine()
+	engine := NewEngine()
+	defer engine.Close()
 	NewEngineWithConfig(NewConfig())
 }
 

--- a/func_test.go
+++ b/func_test.go
@@ -16,6 +16,7 @@ func TestFunc(t *testing.T) {
 
 func TestFuncCall(t *testing.T) {
 	store := NewStore(NewEngine())
+	defer store.Close()
 	called := false
 	cb := func(caller *Caller, args []Val) ([]Val, *Trap) {
 		called = true

--- a/globaltype_test.go
+++ b/globaltype_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestGlobalType(t *testing.T) {
 	ty := NewGlobalType(NewValType(KindI32), true)
+	defer ty.Close()
 	require.Equal(t, KindI32, ty.Content().Kind())
 	require.True(t, ty.Mutable())
 

--- a/linker_test.go
+++ b/linker_test.go
@@ -20,6 +20,7 @@ func TestLinker(t *testing.T) {
 	module, err := NewModule(store.Engine, wasm)
 	require.NoError(t, err)
 	linker := NewLinker(store.Engine)
+	defer linker.Close()
 	require.NoError(t, linker.Define(store, "", "f", WrapFunc(store, func() {})))
 	g, err := NewGlobal(store, NewGlobalType(NewValType(KindI32), false), ValI32(0))
 	require.NoError(t, err)

--- a/module_test.go
+++ b/module_test.go
@@ -34,6 +34,7 @@ func TestModuleImports(t *testing.T) {
 	require.NoError(t, err)
 	module, err := NewModule(NewEngine(), wasm)
 	require.NoError(t, err)
+	defer module.Close()
 	imports := module.Imports()
 	require.Len(t, imports, 4)
 	require.Equal(t, "", imports[0].Module())

--- a/store_test.go
+++ b/store_test.go
@@ -8,7 +8,9 @@ import (
 
 func TestStore(t *testing.T) {
 	engine := NewEngine()
-	NewStore(engine)
+	defer engine.Close()
+	store := NewStore(engine)
+	defer store.Close()
 }
 
 func TestInterruptWasm(t *testing.T) {

--- a/trap.go
+++ b/trap.go
@@ -71,8 +71,23 @@ func mkTrap(ptr *C.wasm_trap_t) *Trap {
 
 func (t *Trap) ptr() *C.wasm_trap_t {
 	ret := t._ptr
+	if ret == nil {
+		panic("object has been closed already")
+	}
 	maybeGC()
 	return ret
+}
+
+// Close will deallocate this type's state explicitly.
+//
+// For more information see the documentation for engine.Close()
+func (t *Trap) Close() {
+	if t._ptr == nil {
+		return
+	}
+	runtime.SetFinalizer(t, nil)
+	C.wasm_trap_delete(t._ptr)
+	t._ptr = nil
 }
 
 // Message returns the message of the `Trap`
@@ -138,6 +153,9 @@ func (t *Trap) Frames() []*Frame {
 
 func (f *Frame) ptr() *C.wasm_frame_t {
 	ret := f._ptr
+	if ret == nil {
+		panic("object has been closed already")
+	}
 	maybeGC()
 	return ret
 }

--- a/val.go
+++ b/val.go
@@ -115,8 +115,23 @@ func (v Val) setDtor() {
 
 func (v Val) ptr() *C.wasmtime_val_t {
 	ret := v._raw
+	if ret == nil {
+		panic("object has been closed already")
+	}
 	maybeGC()
 	return ret
+}
+
+// Close will deallocate this value's state explicitly.
+//
+// For more information see the documentation for engine.Close()
+func (v Val) Close() {
+	if v._raw == nil {
+		return
+	}
+	runtime.SetFinalizer(v._raw, nil)
+	C.wasmtime_val_delete(v._raw)
+	v._raw = nil
 }
 
 // Kind returns the kind of value that this `Val` contains.

--- a/wasi.go
+++ b/wasi.go
@@ -17,15 +17,31 @@ func NewWasiConfig() *WasiConfig {
 	ptr := C.wasi_config_new()
 	config := &WasiConfig{_ptr: ptr}
 	runtime.SetFinalizer(config, func(config *WasiConfig) {
-		C.wasi_config_delete(config._ptr)
+		config.Close()
 	})
 	return config
 }
 
 func (c *WasiConfig) ptr() *C.wasi_config_t {
 	ret := c._ptr
+	if ret == nil {
+		panic("object has been closed already")
+	}
 	maybeGC()
 	return ret
+}
+
+// Close will deallocate this WASI configuration's state explicitly.
+//
+// For more information see the documentation for engine.Close()
+func (c *WasiConfig) Close() {
+	if c._ptr == nil {
+		return
+	}
+	runtime.SetFinalizer(c, nil)
+	C.wasi_config_delete(c._ptr)
+	c._ptr = nil
+
 }
 
 // SetArgv will explicitly configure the argv for this WASI configuration.

--- a/wasi_test.go
+++ b/wasi_test.go
@@ -4,5 +4,6 @@ import "testing"
 
 func TestWasiConfig(t *testing.T) {
 	config := NewWasiConfig()
+	defer config.Close()
 	config.SetEnv([]string{"WASMTIME"}, []string{"GO"})
 }


### PR DESCRIPTION
This commit adds a new `Close` method to most types to explicitly request destruction of FFI resources owned in the Wasmtime C API. This enables more deterministic resource management than purely relying on the Go GC. Note that most types still have finalizers as well, so the `Close` methods are an opt-in way of more explicitly managing resources which is not required.

Closes #209