### PR TITLE
feat: add binding for wasi_config_set_stdin_bytes

### DIFF
--- a/wasi.go
+++ b/wasi.go
@@ -112,6 +112,17 @@ func (c *WasiConfig) SetStdinFile(path string) error {
 	return errors.New("failed to open file")
 }
 
+func (c *WasiConfig) SetStdinBytes(data []byte) {
+	dataC := C.CBytes(data)
+	bytes := C.wasm_byte_vec_t{
+		size: C.size_t(len(data)),
+		data: (*C.wasm_byte_t)(dataC),
+	}
+	C.wasi_config_set_stdin_bytes(c.ptr(), &bytes)
+	runtime.KeepAlive(c)
+	C.free(unsafe.Pointer(dataC))
+}
+
 func (c *WasiConfig) InheritStdin() {
 	C.wasi_config_inherit_stdin(c.ptr())
 	runtime.KeepAlive(c)


### PR DESCRIPTION
Adding a binding for [wasi_config_set_stdin_bytes](https://docs.wasmtime.dev/c-api/wasi_8h.html#a525abd98ade58887a969b796ea05468e)

I've never worked with cgo before, so no idea if this is safe/free of memory leaks, but seems to have worked for me