### PR TITLE
Add Component Model type-hierarchy skeleton + reorganize tests

### DIFF
--- a/component_feat_component_model.go
+++ b/component_feat_component_model.go
@@ -9,18 +9,29 @@ import (
 	"unsafe"
 )
 
-// TODO: expose Component.Type() and the type-reflection hierarchy
-// (ComponentType / ComponentValType / ComponentFuncType / ...) — flagged in
-// review on #281 as the natural next slice, ahead of value handling.
+// TODO: expose ComponentFuncType so callers can introspect a function's
+// parameter and result types.
+// TODO: expose ComponentInstanceType / ComponentResourceType / the composite
+// ComponentValType sub-types (list, record, tuple, variant, enum, option,
+// result, flags, map) so each [ComponentItem] kind has an accessor that
+// returns the embedded payload type. The slice currently exposed here
+// intentionally only surfaces the kinds reachable without those further
+// sub-types.
 // TODO: ComponentFunc + value marshaling (call exported component functions
-// with primitive / composite WIT values). Deferred per #281 review so the
-// component-model-values design can have its own focused thread.
+// with primitive / composite WIT values).
 
 // Component is a compiled WebAssembly component, the binary representation of
 // a component-model artifact. Components are instantiated through a
 // [ComponentLinker].
 type Component struct {
 	_ptr *C.wasmtime_component_t
+
+	// engine is the [Engine] that compiled this component. The component
+	// uses the engine for follow-up queries such as [Component.Type], so
+	// the engine must outlive the component. Held privately so the field
+	// does not commit the package to a public lifecycle contract; can be
+	// promoted later if a user-facing need appears.
+	engine *Engine
 }
 
 // NewComponent compiles a component-model binary into a [Component].
@@ -39,11 +50,11 @@ func NewComponent(engine *Engine, wasm []byte) (*Component, error) {
 	if err != nil {
 		return nil, mkError(err)
 	}
-	return mkComponent(ptr), nil
+	return mkComponent(ptr, engine), nil
 }
 
-func mkComponent(ptr *C.wasmtime_component_t) *Component {
-	c := &Component{_ptr: ptr}
+func mkComponent(ptr *C.wasmtime_component_t, engine *Engine) *Component {
+	c := &Component{_ptr: ptr, engine: engine}
 	runtime.SetFinalizer(c, func(c *Component) {
 		c.Close()
 	})
@@ -93,7 +104,7 @@ func NewComponentDeserialize(engine *Engine, encoded []byte) (*Component, error)
 	if err != nil {
 		return nil, mkError(err)
 	}
-	return mkComponent(ptr), nil
+	return mkComponent(ptr, engine), nil
 }
 
 // NewComponentDeserializeFile is the same as [NewComponentDeserialize] except
@@ -107,7 +118,7 @@ func NewComponentDeserializeFile(engine *Engine, path string) (*Component, error
 	if err != nil {
 		return nil, mkError(err)
 	}
-	return mkComponent(ptr), nil
+	return mkComponent(ptr, engine), nil
 }
 
 // GetExportIndex looks up the export named `name` in this component and
@@ -138,6 +149,15 @@ func (c *Component) GetExportIndex(parent *ComponentExportIndex, name string) *C
 		return nil
 	}
 	return mkComponentExportIndex(idxPtr)
+}
+
+// Type returns the [ComponentType] describing this component's imports
+// and exports. The returned value owns its underlying handle and must be
+// closed (or left to the finalizer).
+func (c *Component) Type() *ComponentType {
+	ptr := C.wasmtime_component_type(c.ptr())
+	runtime.KeepAlive(c)
+	return mkComponentType(ptr, c.engine)
 }
 
 // Close deallocates this component's state explicitly.

--- a/component_feat_component_model_test.go
+++ b/component_feat_component_model_test.go
@@ -1,0 +1,162 @@
+package wasmtime
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// helloComponent is the canonical "smallest non-trivial component" used by
+// the Component-focused tests in this file: a single `hello` function with
+// no arguments or results. Other test files define their own minimal
+// fixtures with file-specific names rather than reaching across files for
+// this constant.
+const helloComponent = `
+(component
+  (core module $m (func (export "hello")))
+  (core instance $i (instantiate $m))
+  (func (export "hello") (canon lift (core func $i "hello"))))
+`
+
+func TestComponentNew(t *testing.T) {
+	helloWasm, err := Wat2Wasm(helloComponent)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		input   []byte
+		wantErr bool
+	}{
+		{"empty", []byte{}, true},
+		{"garbage", []byte{1, 2, 3}, true},
+		{"valid", helloWasm, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newComponentEngine()
+			component, err := NewComponent(engine, tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, component)
+			component.Close()
+		})
+	}
+}
+
+func TestComponentSerializeRoundTripBytes(t *testing.T) {
+	cases := []struct {
+		name           string
+		wat            string
+		wantExportName string
+	}{
+		{
+			"hello_export",
+			`(component
+  (core module $m (func (export "hello")))
+  (core instance $i (instantiate $m))
+  (func (export "hello") (canon lift (core func $i "hello"))))`,
+			"hello",
+		},
+		{
+			"world_export",
+			`(component
+  (core module $m (func (export "world")))
+  (core instance $i (instantiate $m))
+  (func (export "world") (canon lift (core func $i "world"))))`,
+			"world",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newComponentEngine()
+			component := newComponent(t, engine, tc.wat)
+			defer component.Close()
+
+			bytes, err := component.Serialize()
+			require.NoError(t, err)
+			require.NotEmpty(t, bytes)
+
+			round, err := NewComponentDeserialize(engine, bytes)
+			require.NoError(t, err)
+			defer round.Close()
+			require.NotNil(t, round.GetExportIndex(nil, tc.wantExportName))
+		})
+	}
+}
+
+func TestComponentSerializeRoundTripFile(t *testing.T) {
+	cases := []struct {
+		name           string
+		wat            string
+		wantExportName string
+	}{
+		{
+			"hello_export",
+			`(component
+  (core module $m (func (export "hello")))
+  (core instance $i (instantiate $m))
+  (func (export "hello") (canon lift (core func $i "hello"))))`,
+			"hello",
+		},
+		{
+			"world_export",
+			`(component
+  (core module $m (func (export "world")))
+  (core instance $i (instantiate $m))
+  (func (export "world") (canon lift (core func $i "world"))))`,
+			"world",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newComponentEngine()
+			component := newComponent(t, engine, tc.wat)
+			defer component.Close()
+
+			bytes, err := component.Serialize()
+			require.NoError(t, err)
+
+			tmp, err := os.CreateTemp("", "component-serialize")
+			require.NoError(t, err)
+			defer os.Remove(tmp.Name())
+			_, err = tmp.Write(bytes)
+			require.NoError(t, err)
+			require.NoError(t, tmp.Close())
+
+			round, err := NewComponentDeserializeFile(engine, tmp.Name())
+			require.NoError(t, err)
+			defer round.Close()
+			require.NotNil(t, round.GetExportIndex(nil, tc.wantExportName))
+		})
+	}
+}
+
+func TestComponentGetExportIndex(t *testing.T) {
+	engine := newComponentEngine()
+	component := newComponent(t, engine, helloComponent)
+	defer component.Close()
+
+	cases := []struct {
+		name      string
+		target    string
+		wantFound bool
+	}{
+		{"existing", "hello", true},
+		{"missing", "nope", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := component.GetExportIndex(nil, tc.target)
+			if tc.wantFound {
+				require.NotNil(t, idx)
+				idx.Close()
+			} else {
+				require.Nil(t, idx)
+			}
+		})
+	}
+}

--- a/component_linker_feat_component_model_test.go
+++ b/component_linker_feat_component_model_test.go
@@ -1,0 +1,84 @@
+package wasmtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponentInstantiate(t *testing.T) {
+	cases := []struct {
+		name string
+		wat  string
+	}{
+		{
+			"hello_component",
+			`(component
+  (core module $m (func (export "hello")))
+  (core instance $i (instantiate $m))
+  (func (export "hello") (canon lift (core func $i "hello"))))`,
+		},
+		{
+			"empty_component",
+			`(component)`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newComponentEngine()
+			store := NewStore(engine)
+			component := newComponent(t, engine, tc.wat)
+			defer component.Close()
+
+			linker := NewComponentLinker(engine)
+			defer linker.Close()
+
+			instance, err := linker.Instantiate(store, component)
+			require.NoError(t, err)
+			require.NotNil(t, instance)
+		})
+	}
+}
+
+func TestComponentDefineUnknownImportsAsTraps(t *testing.T) {
+	cases := []struct {
+		name string
+		wat  string
+	}{
+		{
+			"single_missing_instance",
+			`(component
+  (import "host:missing/api" (instance
+    (export "f" (func)))))`,
+		},
+		{
+			"two_missing_instances",
+			`(component
+  (import "host:a/api" (instance
+    (export "f" (func))))
+  (import "host:b/api" (instance
+    (export "g" (func)))))`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newComponentEngine()
+			store := NewStore(engine)
+			component := newComponent(t, engine, tc.wat)
+			defer component.Close()
+
+			linker := NewComponentLinker(engine)
+			defer linker.Close()
+
+			// Without trap definitions the missing imports cause instantiation to fail.
+			_, err := linker.Instantiate(store, component)
+			require.Error(t, err, "expected missing import to fail instantiation")
+
+			// After defining unknown imports as traps the instantiation succeeds.
+			require.NoError(t, linker.DefineUnknownImportsAsTraps(component))
+			instance, err := linker.Instantiate(store, component)
+			require.NoError(t, err)
+			require.NotNil(t, instance)
+		})
+	}
+}

--- a/component_test.go
+++ b/component_test.go
@@ -1,7 +1,13 @@
 package wasmtime
 
+// This file holds test helpers and fixture WATs that are shared by the
+// component-model test files (component_feat_component_model_test.go,
+// component_linker_feat_component_model_test.go,
+// component_type_feat_component_model_test.go). It does not correspond to
+// a single production source file; the 1:1 production-test correspondence
+// still applies to the test functions in the other files.
+
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,158 +21,13 @@ func newComponentEngine() *Engine {
 	return NewEngineWithConfig(cfg)
 }
 
-// helloComponent is the smallest non-trivial component used by several tests:
-// a single `hello` function with no arguments or results.
-const helloComponent = `
-(component
-  (core module $m (func (export "hello")))
-  (core instance $i (instantiate $m))
-  (func (export "hello") (canon lift (core func $i "hello"))))
-`
-
-func TestComponentNew(t *testing.T) {
-	helloWasm, err := Wat2Wasm(helloComponent)
-	require.NoError(t, err)
-
-	cases := []struct {
-		name    string
-		input   []byte
-		wantErr bool
-	}{
-		{"empty", []byte{}, true},
-		{"garbage", []byte{1, 2, 3}, true},
-		{"valid", helloWasm, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			engine := newComponentEngine()
-			component, err := NewComponent(engine, tc.input)
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.NotNil(t, component)
-			component.Close()
-		})
-	}
-}
-
-func TestComponentSerializeRoundTripBytes(t *testing.T) {
-	engine := newComponentEngine()
-	wasm, err := Wat2Wasm(helloComponent)
+// newComponent compiles `wat` into a fresh [Component] for tests. The
+// returned component must be closed by the caller.
+func newComponent(t *testing.T, engine *Engine, wat string) *Component {
+	t.Helper()
+	wasm, err := Wat2Wasm(wat)
 	require.NoError(t, err)
 	component, err := NewComponent(engine, wasm)
 	require.NoError(t, err)
-	defer component.Close()
-
-	bytes, err := component.Serialize()
-	require.NoError(t, err)
-	require.NotEmpty(t, bytes)
-
-	round, err := NewComponentDeserialize(engine, bytes)
-	require.NoError(t, err)
-	defer round.Close()
-	require.NotNil(t, round.GetExportIndex(nil, "hello"))
-}
-
-func TestComponentSerializeRoundTripFile(t *testing.T) {
-	engine := newComponentEngine()
-	wasm, err := Wat2Wasm(helloComponent)
-	require.NoError(t, err)
-	component, err := NewComponent(engine, wasm)
-	require.NoError(t, err)
-	defer component.Close()
-
-	bytes, err := component.Serialize()
-	require.NoError(t, err)
-
-	tmp, err := os.CreateTemp("", "component-serialize")
-	require.NoError(t, err)
-	defer os.Remove(tmp.Name())
-	_, err = tmp.Write(bytes)
-	require.NoError(t, err)
-	require.NoError(t, tmp.Close())
-
-	round, err := NewComponentDeserializeFile(engine, tmp.Name())
-	require.NoError(t, err)
-	defer round.Close()
-	require.NotNil(t, round.GetExportIndex(nil, "hello"))
-}
-
-func TestComponentInstantiate(t *testing.T) {
-	engine := newComponentEngine()
-	store := NewStore(engine)
-
-	wasm, err := Wat2Wasm(helloComponent)
-	require.NoError(t, err)
-	component, err := NewComponent(engine, wasm)
-	require.NoError(t, err)
-	defer component.Close()
-
-	linker := NewComponentLinker(engine)
-	defer linker.Close()
-
-	instance, err := linker.Instantiate(store, component)
-	require.NoError(t, err)
-	require.NotNil(t, instance)
-}
-
-func TestComponentDefineUnknownImportsAsTraps(t *testing.T) {
-	engine := newComponentEngine()
-	store := NewStore(engine)
-
-	wasm, err := Wat2Wasm(`
-      (component
-        (import "host:missing/api" (instance
-          (export "f" (func))
-        ))
-      )
-    `)
-	require.NoError(t, err)
-	component, err := NewComponent(engine, wasm)
-	require.NoError(t, err)
-	defer component.Close()
-
-	linker := NewComponentLinker(engine)
-	defer linker.Close()
-
-	// Without trap definitions the missing import causes instantiation to fail.
-	_, err = linker.Instantiate(store, component)
-	require.Error(t, err, "expected missing import to fail instantiation")
-
-	// After defining unknown imports as traps the instantiation succeeds.
-	require.NoError(t, linker.DefineUnknownImportsAsTraps(component))
-	instance, err := linker.Instantiate(store, component)
-	require.NoError(t, err)
-	require.NotNil(t, instance)
-}
-
-func TestComponentGetExportIndex(t *testing.T) {
-	engine := newComponentEngine()
-	wasm, err := Wat2Wasm(helloComponent)
-	require.NoError(t, err)
-	component, err := NewComponent(engine, wasm)
-	require.NoError(t, err)
-	defer component.Close()
-
-	cases := []struct {
-		name      string
-		target    string
-		wantFound bool
-	}{
-		{"existing", "hello", true},
-		{"missing", "nope", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			idx := component.GetExportIndex(nil, tc.target)
-			if tc.wantFound {
-				require.NotNil(t, idx)
-				idx.Close()
-			} else {
-				require.Nil(t, idx)
-			}
-		})
-	}
+	return component
 }

--- a/component_type_feat_component_model.go
+++ b/component_type_feat_component_model.go
@@ -1,0 +1,181 @@
+package wasmtime
+
+// #include <wasmtime.h>
+//
+// static inline uint8_t go_component_item_kind(const wasmtime_component_item_t *it) {
+//   return it->kind;
+// }
+//
+// static inline void go_component_item_get_type(
+//     const wasmtime_component_item_t *it,
+//     wasmtime_component_valtype_t *out) {
+//   wasmtime_component_valtype_clone(&it->of.type, out);
+// }
+import "C"
+
+import "runtime"
+
+// ComponentType describes the type of a [Component] — its lists of imports
+// and exports. Walk the lists with [ComponentType.ImportNth] and
+// [ComponentType.ExportNth]; each entry is a [ComponentItem] whose
+// discriminator identifies the kind of item it carries.
+//
+// A ComponentType is independently owned — closing the parent [Component]
+// does not invalidate it. Close it explicitly (or leave it to the
+// finalizer) when finished.
+type ComponentType struct {
+	_ptr *C.wasmtime_component_type_t
+
+	// engine is the [Engine] the parent [Component] was compiled with. The
+	// type uses the engine for the import / export queries below, so the
+	// engine must outlive the type. Held privately because exposing it does
+	// not enable any user-facing capability that the [Component] does not
+	// already provide.
+	engine *Engine
+}
+
+func mkComponentType(ptr *C.wasmtime_component_type_t, engine *Engine) *ComponentType {
+	ct := &ComponentType{_ptr: ptr, engine: engine}
+	runtime.SetFinalizer(ct, func(ct *ComponentType) {
+		ct.Close()
+	})
+	return ct
+}
+
+func (ct *ComponentType) ptr() *C.wasmtime_component_type_t {
+	ret := ct._ptr
+	if ret == nil {
+		panic("object has been closed already")
+	}
+	maybeGC()
+	return ret
+}
+
+// ImportCount returns the number of imports declared by this component.
+func (ct *ComponentType) ImportCount() int {
+	n := C.wasmtime_component_type_import_count(ct.ptr(), ct.engine.ptr())
+	runtime.KeepAlive(ct)
+	runtime.KeepAlive(ct.engine)
+	return int(n)
+}
+
+// ExportCount returns the number of exports declared by this component.
+func (ct *ComponentType) ExportCount() int {
+	n := C.wasmtime_component_type_export_count(ct.ptr(), ct.engine.ptr())
+	runtime.KeepAlive(ct)
+	runtime.KeepAlive(ct.engine)
+	return int(n)
+}
+
+// ImportNth returns the name and the [ComponentItem] for the `i`-th import.
+// Returns `("", nil)` if `i` is out of range.
+func (ct *ComponentType) ImportNth(i int) (string, *ComponentItem) {
+	return ct.itemNth(i, true)
+}
+
+// ExportNth returns the name and the [ComponentItem] for the `i`-th export.
+// Returns `("", nil)` if `i` is out of range.
+func (ct *ComponentType) ExportNth(i int) (string, *ComponentItem) {
+	return ct.itemNth(i, false)
+}
+
+func (ct *ComponentType) itemNth(i int, isImport bool) (string, *ComponentItem) {
+	var nameP *C.char
+	var nameLen C.size_t
+	var item C.wasmtime_component_item_t
+	var found C.bool
+	if isImport {
+		found = C.wasmtime_component_type_import_nth(
+			ct.ptr(), ct.engine.ptr(), C.size_t(i),
+			&nameP, &nameLen, &item)
+	} else {
+		found = C.wasmtime_component_type_export_nth(
+			ct.ptr(), ct.engine.ptr(), C.size_t(i),
+			&nameP, &nameLen, &item)
+	}
+	runtime.KeepAlive(ct)
+	runtime.KeepAlive(ct.engine)
+	if !bool(found) {
+		return "", nil
+	}
+	name := C.GoStringN(nameP, C.int(nameLen))
+	return name, mkComponentItem(item)
+}
+
+// Close deallocates this component type explicitly.
+func (ct *ComponentType) Close() {
+	if ct._ptr == nil {
+		return
+	}
+	runtime.SetFinalizer(ct, nil)
+	C.wasmtime_component_type_delete(ct._ptr)
+	ct._ptr = nil
+}
+
+// ComponentItemKind discriminates which sub-type a [ComponentItem] carries.
+type ComponentItemKind uint8
+
+const (
+	ComponentItemKindComponent         ComponentItemKind = C.WASMTIME_COMPONENT_ITEM_COMPONENT
+	ComponentItemKindComponentInstance ComponentItemKind = C.WASMTIME_COMPONENT_ITEM_COMPONENT_INSTANCE
+	ComponentItemKindModule            ComponentItemKind = C.WASMTIME_COMPONENT_ITEM_MODULE
+	ComponentItemKindComponentFunc     ComponentItemKind = C.WASMTIME_COMPONENT_ITEM_COMPONENT_FUNC
+	ComponentItemKindResource          ComponentItemKind = C.WASMTIME_COMPONENT_ITEM_RESOURCE
+	ComponentItemKindCoreFunc          ComponentItemKind = C.WASMTIME_COMPONENT_ITEM_CORE_FUNC
+	ComponentItemKindType              ComponentItemKind = C.WASMTIME_COMPONENT_ITEM_TYPE
+)
+
+// ComponentItem is one entry in a component's import or export list.
+//
+// The struct is a discriminated union: a `kind` tag plus a payload that
+// depends on the tag. This release exposes a payload accessor for type-
+// alias entries via [ComponentItem.TypeAlias]. Accessors for the remaining
+// kinds (component, component-instance, module, component-func, resource,
+// core-func) will be wired up in follow-up work.
+type ComponentItem struct {
+	val    C.wasmtime_component_item_t
+	closed bool
+}
+
+func mkComponentItem(val C.wasmtime_component_item_t) *ComponentItem {
+	it := &ComponentItem{val: val}
+	runtime.SetFinalizer(it, func(it *ComponentItem) {
+		it.Close()
+	})
+	return it
+}
+
+// Kind returns the discriminator of this item.
+func (it *ComponentItem) Kind() ComponentItemKind {
+	if it.closed {
+		panic("object has been closed already")
+	}
+	maybeGC()
+	return ComponentItemKind(C.go_component_item_kind(&it.val))
+}
+
+// TypeAlias returns the [ComponentValType] embedded in this item when its
+// kind is [ComponentItemKindType] (a WIT `type X = ...` alias). Returns
+// `nil` for any other kind.
+//
+// The returned [ComponentValType] is independently owned and must be closed
+// (or left to the finalizer).
+func (it *ComponentItem) TypeAlias() *ComponentValType {
+	if it.Kind() != ComponentItemKindType {
+		return nil
+	}
+	var cloned C.wasmtime_component_valtype_t
+	C.go_component_item_get_type(&it.val, &cloned)
+	runtime.KeepAlive(it)
+	return mkComponentValType(cloned)
+}
+
+// Close deallocates this item explicitly.
+func (it *ComponentItem) Close() {
+	if it.closed {
+		return
+	}
+	runtime.SetFinalizer(it, nil)
+	C.wasmtime_component_item_delete(&it.val)
+	it.closed = true
+}

--- a/component_type_feat_component_model_test.go
+++ b/component_type_feat_component_model_test.go
@@ -1,0 +1,246 @@
+package wasmtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// funcExportComponent is the canonical "minimal func export" fixture used
+// by the type-walking tests below to exercise non-Type item kinds. It has
+// a deliberately distinct name from helloComponent (in
+// component_feat_component_model_test.go) so each test file owns its own
+// fixtures rather than sharing a top-level constant across files.
+const funcExportComponent = `
+(component
+  (core module $m (func (export "hello")))
+  (core instance $i (instantiate $m))
+  (func (export "hello") (canon lift (core func $i "hello"))))
+`
+
+// typeAliasU32Component exports a single WIT type alias `my-id = u32`.
+// Used to observe the kind=Type vs kind!=Type axes (the alias name is
+// also probed here so we know name handling works for the Type kind).
+const typeAliasU32Component = `
+(component
+  (type $alias u32)
+  (export "my-id" (type $alias)))
+`
+
+// missingHostInstanceComponent imports a single instance whose function
+// will not be satisfied by an empty linker. Defined here for the
+// type-test scenarios that walk the import side.
+const missingHostInstanceComponent = `
+(component
+  (import "host:missing/api" (instance
+    (export "f" (func)))))
+`
+
+func TestComponentTypeImportExportCount(t *testing.T) {
+	cases := []struct {
+		name        string
+		wat         string
+		wantImports int
+		wantExports int
+	}{
+		{"single_export", funcExportComponent, 0, 1},
+		{"single_import", missingHostInstanceComponent, 1, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newComponentEngine()
+			component := newComponent(t, engine, tc.wat)
+			defer component.Close()
+
+			ct := component.Type()
+			defer ct.Close()
+			require.Equal(t, tc.wantImports, ct.ImportCount())
+			require.Equal(t, tc.wantExports, ct.ExportCount())
+		})
+	}
+}
+
+func TestComponentTypeExportNthReturnsItem(t *testing.T) {
+	engine := newComponentEngine()
+	component := newComponent(t, engine, funcExportComponent)
+	defer component.Close()
+
+	ct := component.Type()
+	defer ct.Close()
+
+	name, item := ct.ExportNth(0)
+	require.NotNil(t, item)
+	defer item.Close()
+	require.Equal(t, "hello", name)
+	require.Equal(t, ComponentItemKindComponentFunc, item.Kind())
+}
+
+func TestComponentTypeExportNthOutOfRange(t *testing.T) {
+	engine := newComponentEngine()
+	component := newComponent(t, engine, funcExportComponent)
+	defer component.Close()
+
+	ct := component.Type()
+	defer ct.Close()
+
+	name, item := ct.ExportNth(1)
+	require.Equal(t, "", name)
+	require.Nil(t, item)
+}
+
+func TestComponentTypeImportNthReturnsItem(t *testing.T) {
+	engine := newComponentEngine()
+	component := newComponent(t, engine, missingHostInstanceComponent)
+	defer component.Close()
+
+	ct := component.Type()
+	defer ct.Close()
+
+	name, item := ct.ImportNth(0)
+	require.NotNil(t, item)
+	defer item.Close()
+	require.Equal(t, "host:missing/api", name)
+	require.Equal(t, ComponentItemKindComponentInstance, item.Kind())
+}
+
+func TestComponentTypeImportNthOutOfRange(t *testing.T) {
+	engine := newComponentEngine()
+	component := newComponent(t, engine, missingHostInstanceComponent)
+	defer component.Close()
+
+	ct := component.Type()
+	defer ct.Close()
+
+	name, item := ct.ImportNth(1)
+	require.Equal(t, "", name)
+	require.Nil(t, item)
+}
+
+func TestComponentItemTypeAlias(t *testing.T) {
+	engine := newComponentEngine()
+	component := newComponent(t, engine, typeAliasU32Component)
+	defer component.Close()
+
+	ct := component.Type()
+	defer ct.Close()
+	require.Equal(t, 1, ct.ExportCount())
+
+	name, item := ct.ExportNth(0)
+	require.NotNil(t, item)
+	defer item.Close()
+	require.Equal(t, "my-id", name)
+	require.Equal(t, ComponentItemKindType, item.Kind())
+
+	vt := item.TypeAlias()
+	require.NotNil(t, vt)
+	defer vt.Close()
+	require.Equal(t, ComponentValTypeKindU32, vt.Kind())
+}
+
+func TestComponentItemTypeAliasReturnsNilForNonTypeKind(t *testing.T) {
+	engine := newComponentEngine()
+	component := newComponent(t, engine, funcExportComponent)
+	defer component.Close()
+
+	ct := component.Type()
+	defer ct.Close()
+	_, item := ct.ExportNth(0)
+	require.NotNil(t, item)
+	defer item.Close()
+	// hello is a func export, not a type alias.
+	require.Nil(t, item.TypeAlias())
+}
+
+// TestComponentTypeWalkMultipleTypeAliases verifies that ExportNth iterates
+// correctly through a component carrying multiple primitive type aliases at
+// distinct positions. Per-kind constant correctness is covered separately by
+// TestComponentValTypeKindForEachPrimitive; this test focuses on the walking
+// semantics — exercising ExportNth at indices > 0 and the (name, kind)
+// coupling for each position in a single multi-type fixture.
+func TestComponentTypeWalkMultipleTypeAliases(t *testing.T) {
+	const wat = `(component
+  (type $b bool)
+  (type $i s32)
+  (type $s string)
+  (export "flag" (type $b))
+  (export "count" (type $i))
+  (export "label" (type $s)))`
+
+	cases := []struct {
+		index    int
+		wantName string
+		wantKind ComponentValTypeKind
+	}{
+		{0, "flag", ComponentValTypeKindBool},
+		{1, "count", ComponentValTypeKindS32},
+		{2, "label", ComponentValTypeKindString},
+	}
+	for _, tc := range cases {
+		t.Run(tc.wantName, func(t *testing.T) {
+			engine := newComponentEngine()
+			component := newComponent(t, engine, wat)
+			defer component.Close()
+
+			ct := component.Type()
+			defer ct.Close()
+			require.Equal(t, 3, ct.ExportCount())
+
+			name, item := ct.ExportNth(tc.index)
+			require.NotNil(t, item)
+			defer item.Close()
+			require.Equal(t, tc.wantName, name)
+			require.Equal(t, ComponentItemKindType, item.Kind())
+
+			vt := item.TypeAlias()
+			require.NotNil(t, vt)
+			defer vt.Close()
+			require.Equal(t, tc.wantKind, vt.Kind())
+		})
+	}
+}
+
+// TestComponentValTypeKindForEachPrimitive triangulates the
+// ComponentValTypeKind* constants for the 13 primitive WIT types. Each
+// case ships a minimal component containing a single type alias of one
+// kind; the test walks the lone export and asserts its observed kind.
+func TestComponentValTypeKindForEachPrimitive(t *testing.T) {
+	cases := []struct {
+		name     string
+		wat      string
+		wantKind ComponentValTypeKind
+	}{
+		{"bool", `(component (type $a bool) (export "a" (type $a)))`, ComponentValTypeKindBool},
+		{"s8", `(component (type $a s8) (export "a" (type $a)))`, ComponentValTypeKindS8},
+		{"s16", `(component (type $a s16) (export "a" (type $a)))`, ComponentValTypeKindS16},
+		{"s32", `(component (type $a s32) (export "a" (type $a)))`, ComponentValTypeKindS32},
+		{"s64", `(component (type $a s64) (export "a" (type $a)))`, ComponentValTypeKindS64},
+		{"u8", `(component (type $a u8) (export "a" (type $a)))`, ComponentValTypeKindU8},
+		{"u16", `(component (type $a u16) (export "a" (type $a)))`, ComponentValTypeKindU16},
+		{"u32", `(component (type $a u32) (export "a" (type $a)))`, ComponentValTypeKindU32},
+		{"u64", `(component (type $a u64) (export "a" (type $a)))`, ComponentValTypeKindU64},
+		{"f32", `(component (type $a f32) (export "a" (type $a)))`, ComponentValTypeKindF32},
+		{"f64", `(component (type $a f64) (export "a" (type $a)))`, ComponentValTypeKindF64},
+		{"char", `(component (type $a char) (export "a" (type $a)))`, ComponentValTypeKindChar},
+		{"string", `(component (type $a string) (export "a" (type $a)))`, ComponentValTypeKindString},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newComponentEngine()
+			component := newComponent(t, engine, tc.wat)
+			defer component.Close()
+
+			ct := component.Type()
+			defer ct.Close()
+
+			_, item := ct.ExportNth(0)
+			require.NotNil(t, item)
+			defer item.Close()
+			require.Equal(t, ComponentItemKindType, item.Kind())
+
+			vt := item.TypeAlias()
+			require.NotNil(t, vt)
+			defer vt.Close()
+			require.Equal(t, tc.wantKind, vt.Kind())
+		})
+	}
+}

--- a/component_valtype_feat_component_model.go
+++ b/component_valtype_feat_component_model.go
@@ -1,0 +1,94 @@
+package wasmtime
+
+// #include <wasmtime.h>
+//
+// static inline uint8_t go_component_valtype_kind(const wasmtime_component_valtype_t *vt) {
+//   return vt->kind;
+// }
+import "C"
+
+import "runtime"
+
+// ComponentValTypeKind discriminates the WIT type that a [ComponentValType]
+// represents. Only constants for the 13 primitive kinds (bool through
+// string) are exposed in this release; constants for the composite kinds
+// (list / record / tuple / variant / enum / option / result / flags / own /
+// borrow / future / stream / error-context / map) are intentionally
+// commented out below — they will be uncommented when each composite kind
+// gets a dedicated payload accessor and a test path that exercises it.
+type ComponentValTypeKind uint8
+
+const (
+	ComponentValTypeKindBool   ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_BOOL
+	ComponentValTypeKindS8     ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_S8
+	ComponentValTypeKindS16    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_S16
+	ComponentValTypeKindS32    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_S32
+	ComponentValTypeKindS64    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_S64
+	ComponentValTypeKindU8     ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_U8
+	ComponentValTypeKindU16    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_U16
+	ComponentValTypeKindU32    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_U32
+	ComponentValTypeKindU64    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_U64
+	ComponentValTypeKindF32    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_F32
+	ComponentValTypeKindF64    ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_F64
+	ComponentValTypeKindChar   ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_CHAR
+	ComponentValTypeKindString ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_STRING
+
+	// Composite-kind constants are deferred until each gets a payload
+	// accessor that returns the corresponding sub-type wrapper, with a
+	// test path. Uncomment as each one lands.
+	//
+	// ComponentValTypeKindList         ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_LIST
+	// ComponentValTypeKindRecord       ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_RECORD
+	// ComponentValTypeKindTuple        ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_TUPLE
+	// ComponentValTypeKindVariant      ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_VARIANT
+	// ComponentValTypeKindEnum         ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_ENUM
+	// ComponentValTypeKindOption       ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_OPTION
+	// ComponentValTypeKindResult       ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_RESULT
+	// ComponentValTypeKindFlags        ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_FLAGS
+	// ComponentValTypeKindOwn          ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_OWN
+	// ComponentValTypeKindBorrow       ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_BORROW
+	// ComponentValTypeKindFuture       ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_FUTURE
+	// ComponentValTypeKindStream       ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_STREAM
+	// ComponentValTypeKindErrorContext ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_ERROR_CONTEXT
+	// ComponentValTypeKindMap          ComponentValTypeKind = C.WASMTIME_COMPONENT_VALTYPE_MAP
+)
+
+// ComponentValType describes the WIT type of a value in the component
+// model.
+//
+// In this release [ComponentValType.Kind] returns one of the 13 primitive
+// [ComponentValTypeKind] constants. If the underlying value type is a
+// composite kind, the returned uint8 will not match any exposed constant
+// — those, along with payload accessors that return their sub-type
+// wrappers, arrive in follow-up work.
+type ComponentValType struct {
+	val    C.wasmtime_component_valtype_t
+	closed bool
+}
+
+func mkComponentValType(val C.wasmtime_component_valtype_t) *ComponentValType {
+	vt := &ComponentValType{val: val}
+	runtime.SetFinalizer(vt, func(vt *ComponentValType) {
+		vt.Close()
+	})
+	return vt
+}
+
+// Kind returns the discriminator of this value type.
+func (vt *ComponentValType) Kind() ComponentValTypeKind {
+	if vt.closed {
+		panic("object has been closed already")
+	}
+	maybeGC()
+	return ComponentValTypeKind(C.go_component_valtype_kind(&vt.val))
+}
+
+// Close deallocates this value type explicitly.
+func (vt *ComponentValType) Close() {
+	if vt.closed {
+		return
+	}
+	runtime.SetFinalizer(vt, nil)
+	C.wasmtime_component_valtype_delete(&vt.val)
+	vt.closed = true
+}


### PR DESCRIPTION
This PR does two things:

- **Type introspection skeleton** — `Component.Type()`, `ComponentType`, `ComponentItem`, `ComponentValType`. `Kind()` accessors only; primitive ValType kinds only.
- **Test file reorganization** — `<source>_test.go` files now mirror production 1:1, no cross-file fixture sharing.

Follow-up to #281 (merged). Tracks #280.

## What's added

- `Component.Type()` returns a `*ComponentType` for walking imports/exports.
- `ComponentItem` is a discriminated union (kind tag + payload). `Kind()` discriminates 7 item kinds; `TypeAlias()` returns the embedded `ComponentValType` when the kind is `Type` (nil otherwise). Payload accessors for the remaining six kinds (component / component-instance / module / component-func / resource / core-func) are deferred to later slices.
- `ComponentValType.Kind()` exposes the 13 primitive WIT kinds (`bool`, `s8`–`s64`, `u8`–`u64`, `f32`/`f64`, `char`, `string`). Constants for the 14 composite kinds are commented out — they will be uncommented when each gets a payload accessor that returns the corresponding sub-type wrapper, with a test path.

## Out of scope (next slices)

Payload accessors for non-`Type` `ComponentItem` kinds, sub-type wrappers for composite `ComponentValType` kinds, and `ComponentFunc` + value marshaling — deferred to follow-up slices.

## Verified

`go build ./...`, `go test ./...` (default + `-tags debug`), `gofmt -l .`, `go vet ./...` all clean. 14 test functions / 28 sub-tests including a 13-case `TestComponentValTypeKindForEachPrimitive` and a 3-case multi-type walk.